### PR TITLE
[Change image name in docker-compose]

### DIFF
--- a/devnet/docker-compose.yml
+++ b/devnet/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   geth:
-    image: geth-local:latest
+    image: peoples93/go-ethereum-limechain:base
     container_name: geth-node
     ports:
       - "8545:8545"


### PR DESCRIPTION
- The old image was a test image only available locally
- The new image points to peoples93/go-ethereum-limechain:base