### PR TITLE
[Fix Geth startup in Dockerfile]

### DIFF
--- a/devnet/Dockerfile
+++ b/devnet/Dockerfile
@@ -5,4 +5,4 @@ FROM peoples93/go-ethereum-limechain:base
 COPY ethereum_data /root/.ethereum
 
 # Run the Geth node with the appropriate flags
-CMD ["geth", "--dev", "--dev.period=12", "--http", "--http.addr=0.0.0.0", "--http.port=8545", "--http.corsdomain='*'", "--http.api=eth,net,web3,personal,debug", "--allow-insecure-unlock", "--verbosity=4", "--datadir=/root/.ethereum"]
+CMD ["--dev", "--dev.period=12", "--http", "--http.addr=0.0.0.0", "--http.port=8545", "--http.corsdomain='*'", "--http.api=eth,net,web3,personal,debug", "--allow-insecure-unlock", "--verbosity=4", "--datadir=/root/.ethereum"]


### PR DESCRIPTION
- Remove 'geth' from CMD instruction
- Allow container to use ENTRYPOINT from base image
- Align Dockerfile with Docker Compose configuration
- Resolve 'invalid command: geth' error on container startup